### PR TITLE
[002] gofmt and testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ build:
 	go build -i -o artifacts/compete github.com/LukeJelly/Cell-Compete-Go
 
 test:
-	go test -race $(go list ./... | grep -v vendor)
+	go list ./... | grep -v vendor | xargs go test -race

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/LukeJelly/Cell-Compete-Go
 
 go 1.13
+
+require github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/groupofcells/groupofcells.go
+++ b/groupofcells/groupofcells.go
@@ -10,17 +10,17 @@ const (
 )
 
 //GroupOfCells is a linkedlist type implementation to the GroupOfCells problem.
-type GroupOfCells struct{
+type GroupOfCells struct {
 	farLeftCell *cell
-	size int
+	size        int
 }
 
 //NewGroupOfCells creates a new group of cells from the given array.
-func NewGroupOfCells(arr []uint8) *GroupOfCells{
+func NewGroupOfCells(arr []uint8) *GroupOfCells {
 	index := 0
 	GPC := GroupOfCells{
-		farLeftCell: makeOneCell(arr[index],nil,nil),
-		size: len(arr),
+		farLeftCell: makeOneCell(arr[index], nil, nil),
+		size:        len(arr),
 	}
 
 	index++
@@ -28,16 +28,16 @@ func NewGroupOfCells(arr []uint8) *GroupOfCells{
 	return &GPC
 }
 
-func makeOneCell(value uint8, left *cell, right *cell) *cell{
+func makeOneCell(value uint8, left *cell, right *cell) *cell {
 	c := cell{
 		value: value,
-		left: left,
+		left:  left,
 		right: right,
 	}
 	return &c
 }
 
-func createGroupOfCellsFromArray(arr []uint8, groupOfCells *GroupOfCells, index int){
+func createGroupOfCellsFromArray(arr []uint8, groupOfCells *GroupOfCells, index int) {
 	var lastUsedCell *cell
 	lastUsedCell = groupOfCells.farLeftCell
 	var currentCell *cell
@@ -49,26 +49,26 @@ func createGroupOfCellsFromArray(arr []uint8, groupOfCells *GroupOfCells, index 
 	}
 }
 
-func (gpc GroupOfCells) String() string{
+func (gpc GroupOfCells) String() string {
 	var output string
 	pointer := gpc.farLeftCell
 	for pointer.right != nil {
-		output += fmt.Sprintf("%v,",pointer.value)
+		output += fmt.Sprintf("%v,", pointer.value)
 		pointer = pointer.right
 	}
-	output += fmt.Sprintf("%v",pointer.value)
+	output += fmt.Sprintf("%v", pointer.value)
 
 	return output
 }
 
 //Compete advances the current group of cells by the given amount
-func (gpc GroupOfCells) Compete(days int){
+func (gpc GroupOfCells) Compete(days int) {
 	for i := 0; i < days; i++ {
 		iterateGroupOfCellsOneDay(&gpc)
 	}
 }
 
-func iterateGroupOfCellsOneDay(gpc *GroupOfCells){
+func iterateGroupOfCellsOneDay(gpc *GroupOfCells) {
 	currentCellPointer := gpc.farLeftCell
 	var leftPreviousValue uint8
 
@@ -80,30 +80,29 @@ func iterateGroupOfCellsOneDay(gpc *GroupOfCells){
 	}
 }
 
-func mutateACell(gpc *GroupOfCells, leftPreviousValue uint8, currentCellPointer *cell){
+func mutateACell(gpc *GroupOfCells, leftPreviousValue uint8, currentCellPointer *cell) {
 	rightValue := findRightCellsValue(currentCellPointer)
-	
-	if(leftPreviousValue == rightValue){
+
+	if leftPreviousValue == rightValue {
 		currentCellPointer.value = Inactive
-	}else{
+	} else {
 		currentCellPointer.value = Active
 	}
 }
 
 func findRightCellsValue(currentCellPointer *cell) uint8 {
 	var rightValue uint8
-	if(currentCellPointer.right == nil){
+	if currentCellPointer.right == nil {
 		rightValue = Inactive
-	}else{
+	} else {
 		rightValue = currentCellPointer.right.value
 	}
 
 	return rightValue
 }
 
-type cell struct{
+type cell struct {
 	value uint8
-	left *cell
+	left  *cell
 	right *cell
 }
-

--- a/groupofcells/groupofcells.go
+++ b/groupofcells/groupofcells.go
@@ -15,6 +15,12 @@ type GroupOfCells struct {
 	size        int
 }
 
+type cell struct {
+	value uint8
+	left  *cell
+	right *cell
+}
+
 //NewGroupOfCells creates a new group of cells from the given array.
 func NewGroupOfCells(arr []uint8) *GroupOfCells {
 	index := 0
@@ -61,6 +67,17 @@ func (gpc GroupOfCells) String() string {
 	return output
 }
 
+func (gpc GroupOfCells) ToSlice() []uint8 {
+	cells := make([]uint8, 0)
+	cell := gpc.farLeftCell
+	for cell.right != nil {
+		cells = append(cells, cell.value)
+		cell = cell.right
+	}
+	cells = append(cells, cell.value)
+	return cells
+}
+
 //Compete advances the current group of cells by the given amount
 func (gpc GroupOfCells) Compete(days int) {
 	for i := 0; i < days; i++ {
@@ -99,10 +116,4 @@ func findRightCellsValue(currentCellPointer *cell) uint8 {
 	}
 
 	return rightValue
-}
-
-type cell struct {
-	value uint8
-	left  *cell
-	right *cell
 }

--- a/groupofcells/groupofcells_test.go
+++ b/groupofcells/groupofcells_test.go
@@ -1,0 +1,27 @@
+package groupofcells
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompete(t *testing.T) {
+	var original = []uint8{1, 0, 0, 0, 0, 1, 0, 0}
+	var expected = []uint8{0, 1, 0, 0, 1, 0, 1, 0}
+	group := NewGroupOfCells(original)
+
+	group.Compete(1)
+	assert.Equal(t, group.ToSlice(), expected, "group should match expected value after one iteration")
+
+	group.Compete(2)
+	assert.NotEqual(t, group.ToSlice(), expected, "group should NOT match expected value after multiple iterations")
+}
+
+func TestCompeteFailure(t *testing.T) {
+	var original = []uint8{1, 0, 0, 0, 0, 1, 0, 0}
+	var expected = []uint8{0} // this is intentionally wrong
+	group := NewGroupOfCells(original)
+
+	group.Compete(1)
+	assert.Equal(t, group.ToSlice(), expected, "this test failed intentionally to demonstrate how tests work")
+}

--- a/main.go
+++ b/main.go
@@ -1,14 +1,13 @@
 package main
 
 import (
-	"github.com/LukeJelly/Cell-Compete-Go/groupofcells"
 	"fmt"
+	"github.com/LukeJelly/Cell-Compete-Go/groupofcells"
 )
 
-
-func main(){
-	var original = []uint8{1,0,0,0,0,1,0,0}
-	var expected = []uint8{0,1,0,0,1,0,1,0}
+func main() {
+	var original = []uint8{1, 0, 0, 0, 0, 1, 0, 0}
+	var expected = []uint8{0, 1, 0, 0, 1, 0, 1, 0}
 	GPC := groupofcells.NewGroupOfCells(original)
 	fmt.Println(GPC)
 	GPC.Compete(1)


### PR DESCRIPTION
Here's a second sample Pull Request. It builds on LukeJelly/Cell-Compete-Go#1.

## golang style

I used `gofmt` to automatically fix a bunch of standard formatting issues. There's a whole host of other guidelines that make this language very stylistically different than Java, for example.

I would suggest reading through [Effective Go](https://golang.org/doc/effective_go.html) as you think about naming things, choosing CamelCase vs snake_case vs lowerCamelCase, etc.

## testing

I added the [stretchr/testify](https://github.com/stretchr/testify) library. (Note: if you didn't understand the [Go Modules](https://github.com/golang/go/wiki/Modules) link from the first PR, the changes to `go.mod` and `go.sum` here will maybe help you decipher it some).

I also demonstrated how you'd write that first `main` program as two tests.

### try it out

```shell
bribera@flask:~/code/Cell-Compete-Go 👻 $ make test
go list ./... | grep -v vendor | xargs go test -race
?   	github.com/LukeJelly/Cell-Compete-Go	[no test files]
--- FAIL: TestCompeteFailure (0.00s)
    groupofcells_test.go:26: 
        	Error Trace:	groupofcells_test.go:26
        	Error:      	Not equal: 
        	            	expected: []byte{0x0, 0x1, 0x0, 0x0, 0x1, 0x0, 0x1, 0x0}
        	            	actual  : []byte{0x0}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,3 +1,3 @@
        	            	-([]uint8) (len=8) {
        	            	- 00000000  00 01 00 00 01 00 01 00                           |........|
        	            	+([]uint8) (len=1) {
        	            	+ 00000000  00                                                |.|
        	            	 }
        	Test:       	TestCompeteFailure
        	Messages:   	this test failed intentionally to demonstrate how tests work
FAIL
FAIL	github.com/LukeJelly/Cell-Compete-Go/groupofcells	0.008s
FAIL
Makefile:7: recipe for target 'test' failed
make: *** [test] Error 123
```